### PR TITLE
Enable KDE Wallet integration for storing credentials

### DIFF
--- a/org.kde.krdc.json
+++ b/org.kde.krdc.json
@@ -18,7 +18,8 @@
         "--socket=wayland",
         "--share=network",
         "--device=dri",
-        "--socket=pulseaudio"
+        "--socket=pulseaudio",
+        "--talk-name=org.kde.kwalletd5"
     ],
     "modules": [
         "shared-modules/libusb/libusb.json",


### PR DESCRIPTION
Enables KDE Wallet integration in order for KRDC to store connection credentials.