### PR TITLE
Fix FreeRDP H.264 streaming

### DIFF
--- a/org.kde.krdc.json
+++ b/org.kde.krdc.json
@@ -21,6 +21,17 @@
         "--socket=pulseaudio",
         "--talk-name=org.kde.kwalletd5"
     ],
+    "add-extensions": {
+        "org.freedesktop.Platform.ffmpeg-full": {
+            "directory": "lib/ffmpeg",
+            "add-ld-path": ".",
+            "version": "22.08",
+            "autodownload": true
+        }
+    },
+    "cleanup-commands": [
+        "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
+    ],
     "modules": [
         "shared-modules/libusb/libusb.json",
         {


### PR DESCRIPTION
Without `ffmpeg-full`, RDP connections (with no extra arguments) won't start:

```
$ QT_LOGGING_RULES="KRDC.debug=true" flatpak run org.kde.krdc
...
KRDC: "[17:42:53:281] [17:17] [ERROR][com.freerdp.codec] - Failed to initialize libav parser\n"
KRDC: "[17:42:53:282] [17:17] [ERROR][com.freerdp.core.codecs] - Failed to create h264 codec context\n"
KRDC: "[17:42:53:283] [17:17] [ERROR][com.freerdp.client.wayland] - Failed to connect\n"
```