### PR TITLE
Enable VA-API support in FreeRDP

### DIFF
--- a/org.kde.krdc.json
+++ b/org.kde.krdc.json
@@ -88,7 +88,8 @@
                 "-DWITH_MANPAGES:BOOL=OFF",
                 "-DWITH_OSS:BOOL=OFF",
                 "-DWITH_SAMPLE:BOOL=OFF",
-                "-DWITH_SERVER:BOOL=OFF"
+                "-DWITH_SERVER:BOOL=OFF",
+                "-DWITH_VAAPI:BOOL=ON"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Depends on https://github.com/flathub/org.kde.krdc/pull/41. VA-API acceleration confirmed working with `/gfx-h264:avc444` when observing `intel_gpu_top`. Requires the correct `org.freedesktop.Platform.VAAPI` Flatpak to be installed.