### PR TITLE
Also allow talking to KF6 KWallet on the host

### DIFF
--- a/org.kde.krdc.json
+++ b/org.kde.krdc.json
@@ -19,7 +19,8 @@
         "--share=network",
         "--device=dri",
         "--socket=pulseaudio",
-        "--talk-name=org.kde.kwalletd5"
+        "--talk-name=org.kde.kwalletd5",
+        "--talk-name=org.kde.kwalletd6"
     ],
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {


### PR DESCRIPTION
Otherwise saving and remembering passwords won't work for KF6-based builds (which this is).

Fixes https://github.com/flathub/org.kde.krdc/issues/79