### PR TITLE
Revert "Enable VA-API support in FreeRDP"

### DIFF
--- a/org.kde.krdc.json
+++ b/org.kde.krdc.json
@@ -97,8 +97,7 @@
                 "-DWITH_MANPAGES:BOOL=OFF",
                 "-DWITH_OSS:BOOL=OFF",
                 "-DWITH_SAMPLE:BOOL=OFF",
-                "-DWITH_SERVER:BOOL=OFF",
-                "-DWITH_VAAPI:BOOL=ON"
+                "-DWITH_SERVER:BOOL=OFF"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Reverts flathub/org.kde.krdc#42

This is apparently causing issues for AMD GPU users.

Let's revert it for now until we can investigate further.

See: https://github.com/flathub/org.kde.krdc/issues/81